### PR TITLE
Output of errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.2
   - 5.3
   - 5.4
 

--- a/typo3-probe.php
+++ b/typo3-probe.php
@@ -1250,6 +1250,12 @@ function printStatus($statuses) {
 				$mode = 'info';
 				break;
 			}
+			
+			case 'ErrorStatus':
+			{
+				$mode = 'error';
+				break;
+			}
 		}
 
 		$content .= '<div class="' . $mode . '">';


### PR DESCRIPTION
I used the script for checking an environment and everything was green. Later in the TYPO3 Install Tool there were some warnings. Coming back to the probe script to take a closer look, I realized that errors are not properly styled.
