### PR TITLE
Add support for a colorized output on the console

### DIFF
--- a/typo3-probe.php
+++ b/typo3-probe.php
@@ -1270,6 +1270,47 @@ function printStatus($statuses) {
 	return $content;
 }
 
+if (PHP_SAPI === 'cli') {
+    foreach ($statuses as $status) {
+        /** @var StatusInterface $status */
+        switch (get_class($status)) {
+            case 'OkStatus':
+            {
+                $mode = "\033[32m" . "OK";
+                break;
+            }
+
+            case 'WarningStatus':
+            {
+                $mode = "\033[33m" . "WARNING";
+                break;
+            }
+
+            case 'NoticeStatus':
+            {
+                $mode = "\033[36m" . "NOTICE";
+                break;
+            }
+
+            case 'InfoStatus':
+            {
+                $mode = "\033[36m" . "INFO";
+                break;
+            }
+
+            case 'ErrorStatus':
+            {
+                $mode = "\033[31m" . "ERROR";
+                break;
+            }
+        }
+        print $mode . "\t" . $status->getTitle() . "\033[0m\n";
+        if ($status->getMessage())
+            print "\t\t\t" . $status->getMessage() . "\n";
+    }
+    die();
+}
+
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
I have to run these tests on the command-line, because I got some errors and warnings in the job in TYPO3. As I can't see them in the install-tool, I wrote a short extension here to list all errors and warnings on the commandline.
